### PR TITLE
Implement basic Socket.IO backend

### DIFF
--- a/bot/index.ts
+++ b/bot/index.ts
@@ -1,0 +1,35 @@
+import { Telegraf } from 'telegraf';
+import axios from 'axios';
+
+const token = process.env.TELE_TOKEN!;
+const api = process.env.API_URL || 'http://localhost:3000';
+const bot = new Telegraf(token);
+
+bot.command('spress', async (ctx) => {
+  const resp = await axios.post(`${api}/create`);
+  const roomId = resp.data.roomId;
+  const url = `https://t.me/${ctx.me}?start=room_${roomId}`;
+  await ctx.reply('Play Spress', {
+    reply_markup: { inline_keyboard: [[{ text: 'Play Spress', url }]] }
+  });
+});
+
+bot.start(async (ctx) => {
+  const payload = ctx.startPayload; // e.g. room_<id>
+  if (payload?.startsWith('room_')) {
+    const roomId = payload.substring(5);
+    await axios.post(`${api}/join`, { roomId, tgUser: ctx.from });
+    const link = `${process.env.PUBLIC_URL || api}/webapp/?roomId=${roomId}`;
+    await ctx.reply(`Joined room ${roomId}`, {
+      reply_markup: { inline_keyboard: [[{ text: 'Open board', web_app: { url: link } }]] }
+    });
+  } else {
+    ctx.reply('Send /spress in a chat to create a game.');
+  }
+});
+
+export default bot;
+
+if (require.main === module) {
+  bot.launch().then(() => console.log('Bot started'));
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "telegraf": "^4.16.3",
-    "ws": "^8.18.2"
+    "ws": "^8.18.2",
+    "socket.io": "^4.7.5",
+    "ioredis": "^5.3.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,56 @@
+import express from 'express';
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+import Redis from 'ioredis';
+import { createAdapter } from '@socket.io/redis-adapter';
+import { randomBytes } from 'crypto';
+
+const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+const redis = new Redis(redisUrl);
+const pub = new Redis(redisUrl);
+const sub = pub.duplicate();
+
+const app = express();
+app.use(express.json());
+const httpServer = createServer(app);
+const io = new Server(httpServer, { cors: { origin: '*' } });
+io.adapter(createAdapter(pub, sub));
+
+const ROOM_TTL = 60 * 60 * 2; // 2h
+
+function makeId() {
+  return randomBytes(4).toString('hex');
+}
+
+app.post('/create', async (_req, res) => {
+  const roomId = makeId();
+  await redis.set(`room:${roomId}`, JSON.stringify({ fen: 'start', players: [] }), 'EX', ROOM_TTL);
+  res.json({ roomId });
+});
+
+app.post('/join', async (req, res) => {
+  const { roomId, tgUser } = req.body || {};
+  if (!roomId || !tgUser) return res.status(400).send('invalid');
+  io.to(roomId).emit('playerJoined', tgUser);
+  res.json({ roomId, tgUser });
+});
+
+io.on('connection', (socket) => {
+  const { roomId } = socket.handshake.query;
+  if (typeof roomId === 'string') socket.join(roomId);
+
+  socket.on('move', async (data) => {
+    io.to(data.roomId).emit('move', data);
+    if (data.fen) {
+      await redis.set(`room:${data.roomId}`, JSON.stringify({ fen: data.fen }), 'EX', ROOM_TTL);
+    }
+  });
+});
+
+export function start(port: number) {
+  httpServer.listen(port, () => console.log(`\u{1F680} server on ${port}`));
+}
+
+if (require.main === module) {
+  start(Number(process.env.PORT) || 3000);
+}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -16,7 +16,8 @@
     "react-chessboard": "^4.7.3",
     "react-dom": "^18.3.1",
     "reconnecting-websocket": "^4.4.0",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/webapp/src/components/PlayerBadge.tsx
+++ b/webapp/src/components/PlayerBadge.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface PlayerBadgeProps {
+  pfp: string;
+  srcName: string;
+  score: number;
+  color: 'white' | 'black';
+}
+
+export default function PlayerBadge({ pfp, srcName, score, color }: PlayerBadgeProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <img src={pfp} alt={srcName} className="w-8 h-8 rounded-full" />
+      <span className="font-semibold">{srcName}</span>
+      <span className="text-sm">{score}</span>
+      <span className={`px-1 rounded text-xs ${color === 'white' ? 'bg-gray-200' : 'bg-gray-700 text-white'}`}>{color}</span>
+    </div>
+  );
+}

--- a/webapp/src/hooks/useSocket.ts
+++ b/webapp/src/hooks/useSocket.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react';
+import { io, Socket } from 'socket.io-client';
+
+export function useSocket(roomId: string) {
+  const socketRef = useRef<Socket>();
+
+  useEffect(() => {
+    const socket = io('/', { query: { roomId } });
+    socketRef.current = socket;
+    return () => { socket.disconnect(); };
+  }, [roomId]);
+
+  return socketRef;
+}
+export default useSocket;


### PR DESCRIPTION
## Summary
- add socket.io based server with Redis adapter
- add Telegraf bot glue to create and join rooms
- provide React hook for Socket.IO client connections
- add PlayerBadge component stub
- revert README to avoid binary diff

## Testing
- `npm test` *(fails: no test specified)*
- `pnpm i`
- `pnpm run build`
- `pnpm dev` *(fails: spawn xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6861936d3ab08324a45146ef3c9b1329