### PR TITLE
Improve piece dragging

### DIFF
--- a/webapp/dist/index.html
+++ b/webapp/dist/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SPRESS Chess</title>
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <script type="module" crossorigin src="/webapp/assets/index-e5a0c972.js"></script>
+    <script type="module" crossorigin src="/webapp/assets/index-38a733f1.js"></script>
     <link rel="stylesheet" href="/webapp/assets/index-737ad71f.css">
   </head>
   <body>

--- a/webapp/src/Board.tsx
+++ b/webapp/src/Board.tsx
@@ -76,6 +76,15 @@ export default function Board({ fen, turn, isGameOver, isInCheck, color, onMoveA
   // Mobile drag/tap conflict prevention
   const isDragging = useRef(false);
 
+  // Only allow dragging of our own pieces
+  const isDraggablePiece = useCallback(
+    ({ piece }: { piece: string; sourceSquare: string }) => {
+      if (turn !== color || isGameOver) return false;
+      return piece[0] === color;
+    },
+    [turn, color, isGameOver]
+  );
+
   // Use the stable piece renderers - this reference NEVER changes
   const customPieces = STABLE_PIECE_RENDERERS;
 
@@ -181,8 +190,8 @@ export default function Board({ fen, turn, isGameOver, isInCheck, color, onMoveA
         captureSquare: move.captured ? targetSquare : undefined
       });
       
-      // Always return false - piece will snap back, server will update position later
-      return false;
+      // Let piece stay on target square; board will update when server confirms
+      return true;
     },
     [turn, color, isGameOver, onMoveAttempt],
   );
@@ -357,6 +366,7 @@ export default function Board({ fen, turn, isGameOver, isInCheck, color, onMoveA
           transition: 'transform 0.15s ease-out'
         }}
         arePiecesDraggable={turn === color && !isGameOver}
+        isDraggablePiece={isDraggablePiece}
       />
       
       {/* Capture Toast */}


### PR DESCRIPTION
## Summary
- restrict piece dragging so you can only move your own pieces
- let pieces stay on the target square until the server updates
- rebuild webapp

## Testing
- `npm run build:bot`
- `npm run build:webapp`

------
https://chatgpt.com/codex/tasks/task_e_68687956f1c883248173aad7eb7e4751