### PR TITLE
Enable DM board updates in PvP mode

### DIFF
--- a/src/utils/boardText.ts
+++ b/src/utils/boardText.ts
@@ -1,0 +1,25 @@
+import { Chess } from 'chess.js';
+
+/**
+ * Convert FEN string to a simple ASCII board for Telegram messages.
+ */
+export function boardTextFromFEN(fen: string): string {
+  const chess = new Chess(fen);
+  const board = chess.board();
+  let txt = '```\n  a b c d e f g h\n';
+  for (let r = 7; r >= 0; r--) {
+    txt += (r + 1) + ' ';
+    for (let f = 0; f < 8; f++) {
+      const piece = board[r][f];
+      if (piece) {
+        txt += piece.color === 'w' ? piece.type.toUpperCase() : piece.type.toLowerCase();
+      } else {
+        txt += '.';
+      }
+      txt += ' ';
+    }
+    txt += (r + 1) + '\n';
+  }
+  txt += '  a b c d e f g h\n```';
+  return txt;
+}

--- a/src/wsHub.ts
+++ b/src/wsHub.ts
@@ -3,6 +3,7 @@ import { Chess } from 'chess.js';
 import bestMove from './engine/stockfish';
 import { getGame, updateGame, deleteGame, updateLastDm, games } from './store/db';
 import { ensureHttps } from './utils/ensureHttps';
+import { boardTextFromFEN } from './utils/boardText';
 import { GameSession } from './types';
 
 interface SessionClients {
@@ -72,8 +73,10 @@ export async function sendTurnNotification(gameSession: GameSession, captureInfo
   // 2) Optional personal DM (only if we stored dmChatId and it's different from origin)
   if (player.dmChatId && player.dmChatId !== gameSession.chatId) {
     try {
-      await botInstance.telegram.sendMessage(player.dmChatId, text, { 
-        reply_markup: markup 
+      const boardText = boardTextFromFEN(gameSession.fen);
+      await botInstance.telegram.sendMessage(player.dmChatId, `${text}\n${boardText}`, {
+        parse_mode: 'Markdown',
+        reply_markup: markup
       });
       console.log(`✅ Sent DM to user ${player.id}`);
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- send players the board via DM on game start
- include board ASCII text in turn notifications
- utility helper to render FEN as an ASCII board

## Testing
- `npm run build:bot`
- `npm run build:webapp`

------
https://chatgpt.com/codex/tasks/task_e_686879b2c9c083248ca2ae652e07d11e