### PR TITLE
Improve bot commands and stats

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -106,7 +106,7 @@ app.get('/health', (req, res) => {
 });
 
 // Import command handlers
-import { handleNewGame, handleSoloGame, handleMove, handleResign, handleCallbackQuery } from './telechess/commands';
+import { handleNewGame, handleSoloGame, handleMove, handleResign, handleCallbackQuery, handleStats } from './telechess/commands';
 
 // Set up bot commands
 if (bot) {
@@ -125,6 +125,7 @@ if (bot) {
       '/new @opponent - Start a new game\n' +
       '/solo - Play vs AI\n' +
       '/resign - Resign current game\n' +
+      '/stats - Show your stats\n' +
       'Use the interactive board to make moves\n' +
       'Click "♟️ Launch SPRESS Board" to play'
     );
@@ -134,6 +135,7 @@ if (bot) {
   bot.command('new', handleNewGame);
 bot.command('solo', handleSoloGame);
 bot.command('resign', handleResign);
+bot.command('stats', handleStats);
 
 // Reset command for testing (admin only)
 bot.command('reset', (ctx) => {

--- a/src/store/stats.ts
+++ b/src/store/stats.ts
@@ -1,0 +1,75 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface PlayerStats {
+  pvpWins: number;
+  pvpLosses: number;
+  pvpDraws: number;
+  soloWins: number;
+  soloLosses: number;
+  soloDraws: number;
+}
+
+const statsPath = path.join(__dirname, 'stats.json');
+let stats: Record<string, PlayerStats> = {};
+
+export function loadStats() {
+  try {
+    if (fs.existsSync(statsPath)) {
+      stats = JSON.parse(fs.readFileSync(statsPath, 'utf8')) as Record<string, PlayerStats>;
+    }
+  } catch (err) {
+    console.error('Failed to load stats:', err);
+  }
+}
+
+export function saveStats() {
+  try {
+    fs.writeFileSync(statsPath, JSON.stringify(stats, null, 2));
+  } catch (err) {
+    console.error('Failed to save stats:', err);
+  }
+}
+
+loadStats();
+
+function ensureUser(id: number) {
+  if (!stats[id]) {
+    stats[id] = {
+      pvpWins: 0,
+      pvpLosses: 0,
+      pvpDraws: 0,
+      soloWins: 0,
+      soloLosses: 0,
+      soloDraws: 0
+    };
+  }
+}
+
+export function recordResult(whiteId: number, blackId: number, result: 'white'|'black'|'draw', mode: 'pvp'|'ai') {
+  ensureUser(whiteId);
+  ensureUser(blackId);
+  if (mode === 'pvp') {
+    if (result === 'white') {
+      stats[whiteId].pvpWins++;
+      stats[blackId].pvpLosses++;
+    } else if (result === 'black') {
+      stats[blackId].pvpWins++;
+      stats[whiteId].pvpLosses++;
+    } else {
+      stats[whiteId].pvpDraws++;
+      stats[blackId].pvpDraws++;
+    }
+  } else {
+    // solo mode: whiteId is human, blackId is AI (-1)
+    if (result === 'white') stats[whiteId].soloWins++;
+    else if (result === 'black') stats[whiteId].soloLosses++;
+    else stats[whiteId].soloDraws++;
+  }
+  saveStats();
+}
+
+export function getStats(userId: number): PlayerStats {
+  ensureUser(userId);
+  return stats[userId];
+}


### PR DESCRIPTION
## Summary
- fix challenge messaging in groups
- track win/loss/draw stats in new stats store
- resign and game end update player stats
- show real board position when requesting board view
- add `/stats` command and update help text

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6868865ef3f883248acfb46f04991b67