### PR TITLE
Fix tests by mocking chess-image-generator

### DIFF
--- a/__mocks__/chess-image-generator.ts
+++ b/__mocks__/chess-image-generator.ts
@@ -1,0 +1,4 @@
+module.exports = jest.fn().mockImplementation(() => ({
+  loadFEN: jest.fn(),
+  generatePNGBuffer: jest.fn().mockResolvedValue(Buffer.from('mock'))
+}));

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  moduleNameMapper: {
-    '^../src/store/stats$': '<rootDir>/src/store/stats.ts'
+moduleNameMapper: {
+    '^../src/store/stats$': '<rootDir>/src/store/stats.ts',
+    'chess-image-generator': '<rootDir>/__mocks__/chess-image-generator.ts'
   }
 };

--- a/src/types/chess-image-generator.d.ts
+++ b/src/types/chess-image-generator.d.ts
@@ -1,0 +1,1 @@
+declare module 'chess-image-generator';


### PR DESCRIPTION
## Summary
- mock `chess-image-generator` for tests
- add module declaration for TypeScript
- map mock in Jest config

## Testing
- `npm test`
- `npm run lint` *(fails: 26 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6869df01a18c832492935ebc7b1d0e5a