### PR TITLE
Fix PvP for group chat play

### DIFF
--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -75,7 +75,18 @@ export const updateLastDm = {
 
 // User registry functions
 export const registerUser = (userId: number, dmChatId: number, username?: string) => {
-  userRegistry[userId] = { dmChatId, username };
+  // Only update dmChatId if it's a private chat (individual DM)
+  // Group chats have negative IDs, private chats have positive IDs
+  if (dmChatId > 0) {
+    userRegistry[userId] = { dmChatId, username };
+  } else {
+    // For group chats, only update username if user doesn't exist yet
+    if (!userRegistry[userId]) {
+      userRegistry[userId] = { dmChatId: 0, username };
+    } else {
+      userRegistry[userId].username = username;
+    }
+  }
 };
 
 export const getUser = (userId: number) => {

--- a/src/wsHub.ts
+++ b/src/wsHub.ts
@@ -75,8 +75,8 @@ export async function sendTurnNotification(gameSession: GameSession, captureInfo
     console.error('Failed to notify origin chat:', (err as Error)?.message || err);
   }
 
-  // 2) Optional personal DM (only if we stored dmChatId and it's different from origin)
-  if (player.dmChatId && player.dmChatId !== gameSession.chatId) {
+  // 2) Optional personal DM (only if we stored dmChatId and it's different from origin and is a valid private chat)
+  if (player.dmChatId && player.dmChatId > 0 && player.dmChatId !== gameSession.chatId) {
     try {
       const boardText = boardTextFromFEN(gameSession.fen);
       await botInstance.telegram.sendMessage(player.dmChatId, `${text}\n${boardText}`, {


### PR DESCRIPTION
Fix PVP functionality to allow playing against others while the bot is in a group chat by ensuring direct messages are sent to individual users, not group chats.

The bot was incorrectly attempting to send direct messages (DMs) to group chat IDs (which are negative) instead of individual user private chat IDs (which are positive). This prevented users from receiving personal game notifications and broke the PVP flow in group environments.