### PR TITLE
Initialize Telegram bridge and add troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ The chess board opens as a Telegram Web App with:
 - Telegram theme integration
 - Haptic feedback support
 
+### Troubleshooting Telegram Mini Apps
+
+- **Blank screen on Android** – ensure your server provides the **full SSL
+  certificate chain**. Serving only the leaf certificate can cause Telegram’s
+  Android webview to block the request entirely.
+- **Stuck loading** – some Telegram versions (for example v10.2.2 on Android)
+  had bugs preventing mini apps from launching. Updating the Telegram client
+  typically resolves this.
+
 ## 🎯 Future Enhancements
 
 - [ ] Custom piece graphics

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -1,8 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { MiniKitProvider } from '@coinbase/onchainkit/minikit'
+import { TelegramBridge } from './TelegramBridge'
 import './index.css'
 import App from './App.tsx'
+
+// Initialize Telegram SDK if available. This calls WebApp.ready() and
+// WebApp.expand() so the mini-app properly loads inside Telegram.
+TelegramBridge.getInstance()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- call `TelegramBridge.getInstance()` so `WebApp.ready()` runs
- document Mini App troubleshooting steps for Android issues

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68785f8e5aac832487d6a098c8f639d5