### PR TITLE
Fix solo difficulty callback

### DIFF
--- a/dist/telechess/commands.js
+++ b/dist/telechess/commands.js
@@ -401,9 +401,9 @@ async function handleCallbackQuery(ctx) {
     }
     else if (data === 'solo_easy' || data === 'solo_med' || data === 'solo_hard') {
         const level = data === 'solo_easy' ? 2 : data === 'solo_med' ? 10 : 15;
-        // Use a plain object spread to override message
-        const ctxForSolo = { ...ctx, message: { text: `/solo ${level}` } };
-        await handleSoloGame(ctxForSolo);
+        // Directly assign a fake message to ctx to preserve all properties and methods
+        ctx.message = { text: `/solo ${level}` };
+        await handleSoloGame(ctx);
         ctx.answerCbQuery();
     }
     else if (data.startsWith('help_')) {


### PR DESCRIPTION
## Summary
- rebuild `dist/telechess/commands.js`
- inline difficulty callback handler preserves original context

## Testing
- `npm test`
- `node` script exercising solo difficulty callback

------
https://chatgpt.com/codex/tasks/task_e_687a72a2c5f883248dd1ae2ff5e5a312