### PR TITLE
Serve built webapp and tweak solo UI

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { Telegraf } from 'telegraf';
 import dotenv from 'dotenv';
 import http from 'http';
 import path from 'node:path';
+import fs from 'node:fs';
 import { initWS, setBotInstance } from './wsHub';
 import { registerUser } from './store/db';
 import { games, loadGames, purgeFinished } from './store/games';
@@ -59,63 +60,42 @@ if (bot) {
 app.use(express.json());
 app.use(express.static('public'));
 
-// Serve webapp static files in production or fallback
-if (process.env.NODE_ENV === 'production') {
+// Serve webapp static files if built, otherwise show development hint
+{
   const webappDistPath = path.join(__dirname, '../webapp/dist');
   const webappIndexPath = path.join(webappDistPath, 'index.html');
-  
-  logger.info('🌐 Setting up webapp static files...');
-  logger.info({ webappDistPath, webappIndexPath }, 'paths');
-  
-  // Serve static files
-  app.use('/webapp', express.static(webappDistPath, { maxAge: '1h' }));
-  
-  // Explicit route for pieces (fallback safety - ensures PNGs are accessible)
-  app.use('/webapp/pieces', express.static(path.join(webappDistPath, 'pieces'), { maxAge: '1h' }));
-  
-  // Serve index.html for all webapp routes
-  app.get('/webapp/*', (_req, res) => {
-    res.sendFile(webappIndexPath, (err) => {
-      if (err) {
-        logger.error({ err }, 'Failed to serve webapp index.html');
-        res.status(500).send(`
-          <!DOCTYPE html>
-          <html>
-          <head><title>SPRESS Chess</title></head>
-          <body style="background:#00102E;color:#FFD700;font-family:system-ui;text-align:center;padding:50px;">
-            <h1>🏗️ SPRESS Chess</h1>
-            <p>Mini App is being built...</p>
-            <p>Use bot commands for now: /new @username</p>
-            <p>Check back soon for the interactive board!</p>
-          </body>
-          </html>
-        `);
-      }
-    });
-  });
+  const hasWebappBuild = fs.existsSync(webappIndexPath);
 
-  // Serve index.html for GET /bot to support Telegram Mini App launches
-  app.get('/bot', (_req, res) => {
-    res.sendFile(webappIndexPath, err => {
-      if (err) {
-        logger.error(err, 'Failed to serve webapp index for /bot');
-        res.status(500).send('Error loading app interface.');
-      }
+  logger.info('🌐 Webapp build ' + (hasWebappBuild ? 'found' : 'not found'));
+
+  if (hasWebappBuild) {
+    app.use('/webapp', express.static(webappDistPath, { maxAge: '1h' }));
+    app.use('/webapp/pieces', express.static(path.join(webappDistPath, 'pieces'), { maxAge: '1h' }));
+
+    const serveIndex = (_req: express.Request, res: express.Response) => {
+      res.sendFile(webappIndexPath, err => {
+        if (err) {
+          logger.error({ err }, 'Failed to serve webapp index.html');
+          res.status(500).send('Error loading app interface.');
+        }
+      });
+    };
+
+    app.get('/webapp/*', serveIndex);
+    app.get('/bot', serveIndex);
+  } else {
+    app.get('/webapp/*', (_req, res) => {
+      res.send(`
+        <html>
+          <body>
+            <h1>Development Mode</h1>
+            <p>Start the webapp dev server: <code>cd webapp && npm run dev</code></p>
+            <p>Then visit: <a href="http://localhost:5173">http://localhost:5173</a></p>
+          </body>
+        </html>
+      `);
     });
-  });
-} else {
-  // In development, just serve a simple message
-  app.get('/webapp/*', (_req, res) => {
-    res.send(`
-      <html>
-        <body>
-          <h1>Development Mode</h1>
-          <p>Start the webapp dev server: <code>cd webapp && npm run dev</code></p>
-          <p>Then visit: <a href="http://localhost:5173">http://localhost:5173</a></p>
-        </body>
-      </html>
-    `);
-  });
+  }
 }
 
 // WebSocket handling is now done in wsHub.ts

--- a/src/telechess/commands.ts
+++ b/src/telechess/commands.ts
@@ -167,8 +167,7 @@ export async function handleSoloGame(ctx: Context) {
   await ctx.reply('🤖 Solo Mode - You vs AI', {
     reply_markup: {
       inline_keyboard: [
-        [{ text: '🤖 Play Solo', web_app: { url } }],
-        [{ text: '👀 Watch', callback_data: `spectate_${sessionId}` }]
+        [{ text: '🤖 Play Solo', web_app: { url } }]
       ]
     }
   });


### PR DESCRIPTION
## Summary
- load webapp build if present instead of showing a dev message
- remove the useless *Watch* button from solo games

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a89cc35f48324a82c9b6a4a18758a