### PR TITLE
Improve Railway startup by auto-building webapp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ COPY . .
 RUN npm run build
 
 EXPOSE 9000
-CMD ["node", "dist/server.js"]
+CMD ["node", "start.js"]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm test
 # Build both backend and webapp
 npm run build
 
-# Start production server
+# Start production server (auto-builds webapp if missing)
 npm start
 ```
 

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -18,4 +18,4 @@ cmds = [
 ]
 
 [start]
-cmd = "node dist/server.js" 
+cmd = "node start.js"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:bot": "echo 'Using pre-compiled dist files'",
     "build:webapp": "cd webapp && npm run build",
     "build": "npm run build:bot && npm run build:webapp",
-    "start": "node dist/server.js",
+    "start": "node start.js",
     "test": "jest",
     "lint": "eslint --ext .ts src"
   },

--- a/start.js
+++ b/start.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+const path = require('path');
+
+// Path to the built React app
+const webappIndex = path.join(__dirname, 'webapp', 'dist', 'index.html');
+
+// If the webapp isn't built, build it now so Express can serve it
+if (!fs.existsSync(webappIndex)) {
+  console.log('🔧 webapp build not found - running "npm run build:webapp"...');
+  execSync('npm run build:webapp', { stdio: 'inherit' });
+}
+
+// Start the precompiled server
+require('./dist/server.js');


### PR DESCRIPTION
## Summary
- add `start.js` helper that builds the React webapp if it hasn't been built
- point the Dockerfile and Nixpacks start command at this script
- update npm start script and README usage notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a99cc4d1483248417b00b2033f5be