### PR TITLE
Fix canvas install on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM node:20-alpine
+FROM node:20-slim
 
-# sys deps for better-sqlite3
-RUN apk add --no-cache python3 make g++
+# System dependencies for native modules
+RUN apt-get update \
+    && apt-get install -y python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- change Dockerfile base image from `node:20-alpine` to `node:20-slim`
- install build tools using apt

This resolves `npm ci` failures due to missing canvas binaries for musl.

## Testing
- `npm ci`
- `cd webapp && npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ad26eb75c83249790a87fae1bb16d