### PR TITLE
Fix local webapp links

### DIFF
--- a/src/utils/ensureHttps.ts
+++ b/src/utils/ensureHttps.ts
@@ -1,2 +1,12 @@
-export const ensureHttps = (url: string) =>
-  url.startsWith('http') ? url : `https://${url.replace(/^\/+/, '')}`; 
+export const ensureHttps = (url: string) => {
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url;
+  }
+
+  // Use plain HTTP for localhost to avoid certificate issues in development
+  if (url.startsWith('localhost') || url.startsWith('127.0.0.1')) {
+    return `http://${url.replace(/^\/+/, '')}`;
+  }
+
+  return `https://${url.replace(/^\/+/, '')}`;
+};


### PR DESCRIPTION
## Summary
- allow http for localhost when generating PUBLIC_URL links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b1843e58483248cd53658b79e10d4