### PR TITLE
Fix webapp port exposure

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -76,10 +76,21 @@ In production, Express serves:
 - Pieces: `https://your-app.railway.app/webapp/pieces/*.svg`
 - WebSocket: `wss://your-app.railway.app/ws`
 
-The Telegram bot generates links like:`https://your-app.railway.app/webapp/?session=123&color=w` 
-### Prometheus on Fly
+The Telegram bot generates links like:`https://your-app.railway.app/webapp/?session=123&color=w`
+
+### Fly.io Services
 Add to `fly.toml`:
 ```toml
+[[services]]
+  internal_port = 3000
+  protocol = "tcp"
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
 [[services]]
   internal_port = 9000
   protocol = "tcp"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,6 @@ COPY . .
 # Build the project
 RUN npm run build
 
+EXPOSE 3000
 EXPOSE 9000
 CMD ["node", "start.js"]

--- a/README.md
+++ b/README.md
@@ -106,8 +106,23 @@ WEBAPP_URL=https://yourapp.com/webapp
 METRICS_PORT=9000
 ENABLE_SHARE_HOOK=0
 ```
-To expose the Prometheus metrics endpoint on Fly, add to `fly.toml`:
+
+`PUBLIC_URL` **must** match the public domain of your deployment (for example
+`https://mychess.fly.dev`). The server listens on `PORT` (3000 by default), so
+your hosting provider needs to route traffic to this port.
+
+On Fly.io, add the following services to `fly.toml`:
 ```toml
+[[services]]
+  internal_port = 3000
+  protocol = "tcp"
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
 [[services]]
   internal_port = 9000
   protocol = "tcp"

--- a/fly.toml
+++ b/fly.toml
@@ -5,3 +5,20 @@ DATABASE_URL = "/data/chess.sqlite"
 [[mounts]]
 source="db"
 destination="/data"
+
+[[services]]
+  internal_port = 3000
+  protocol = "tcp"
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+[[services]]
+  internal_port = 9000
+  protocol = "tcp"
+  [[services.ports]]
+    port = 9000
+    handlers = ["http"]


### PR DESCRIPTION
## Summary
- expose port 3000 in Dockerfile
- document `fly.toml` service blocks for ports 3000 and 9000
- clarify PUBLIC_URL requirement in README
- add default service entries to `fly.toml`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d2f67515c8324958870c65bdaca0c