### PR TITLE
Ensure DB persists across restarts

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -76,10 +76,21 @@ In production, Express serves:
 - Pieces: `https://your-app.railway.app/webapp/pieces/*.svg`
 - WebSocket: `wss://your-app.railway.app/ws`
 
-The Telegram bot generates links like:`https://your-app.railway.app/webapp/?session=123&color=w` 
-### Prometheus on Fly
+The Telegram bot generates links like:`https://your-app.railway.app/webapp/?session=123&color=w`
+
+### Fly.io Services
 Add to `fly.toml`:
 ```toml
+[[services]]
+  internal_port = 3000
+  protocol = "tcp"
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
 [[services]]
   internal_port = 9000
   protocol = "tcp"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ RUN apt-get update \
 
 WORKDIR /app
 
+# Directory for persistent SQLite database
+RUN mkdir -p /data
+VOLUME ["/data"]
+
 # Copy root package files and install dependencies
 COPY package*.json ./
 RUN npm ci
@@ -22,5 +26,6 @@ COPY . .
 # Build the project
 RUN npm run build
 
+EXPOSE 3000
 EXPOSE 9000
 CMD ["node", "start.js"]

--- a/README.md
+++ b/README.md
@@ -106,8 +106,23 @@ WEBAPP_URL=https://yourapp.com/webapp
 METRICS_PORT=9000
 ENABLE_SHARE_HOOK=0
 ```
-To expose the Prometheus metrics endpoint on Fly, add to `fly.toml`:
+
+`PUBLIC_URL` **must** match the public domain of your deployment (for example
+`https://mychess.fly.dev`). The server listens on `PORT` (3000 by default), so
+your hosting provider needs to route traffic to this port.
+
+On Fly.io, add the following services to `fly.toml`:
 ```toml
+[[services]]
+  internal_port = 3000
+  protocol = "tcp"
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
 [[services]]
   internal_port = 9000
   protocol = "tcp"
@@ -115,6 +130,24 @@ To expose the Prometheus metrics endpoint on Fly, add to `fly.toml`:
     port = 9000
     handlers = ["http"]
 ```
+
+
+### Persistent Storage
+When `/data` exists, the server stores games in a SQLite database at
+`/data/games.db`. Mount this path as a volume so games persist after container
+restarts. Example `docker-compose.yml`:
+
+```yaml
+services:
+  spress:
+    volumes:
+      - spress_data:/data
+
+volumes:
+  spress_data:
+```
+
+For `docker run`, append `-v spress_data:/data`.
 
 ### Optional: Board Image Support
 Install the [`chess-image-generator`](https://www.npmjs.com/package/chess-image-generator) package if

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  spress:
+    build: .
+    ports:
+      - "3000:3000"
+      - "9000:9000"
+    volumes:
+      - spress_data:/data
+    environment:
+      TELE_TOKEN: "your_telegram_bot_token"
+      PUBLIC_URL: "https://your-app.example.com"
+volumes:
+  spress_data:

--- a/fly.toml
+++ b/fly.toml
@@ -5,3 +5,20 @@ DATABASE_URL = "/data/chess.sqlite"
 [[mounts]]
 source="db"
 destination="/data"
+
+[[services]]
+  internal_port = 3000
+  protocol = "tcp"
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+[[services]]
+  internal_port = 9000
+  protocol = "tcp"
+  [[services.ports]]
+    port = 9000
+    handlers = ["http"]

--- a/start.js
+++ b/start.js
@@ -5,6 +5,12 @@ const path = require('path');
 // Path to the built React app
 const webappIndex = path.join(__dirname, 'webapp', 'dist', 'index.html');
 
+// Ensure persistent data directory exists before server imports DB module
+const dataDir = '/data';
+if (!fs.existsSync(dataDir)) {
+  fs.mkdirSync(dataDir, { recursive: true });
+}
+
 // If the webapp isn't built, build it now so Express can serve it
 if (!fs.existsSync(webappIndex)) {
   console.log('🔧 webapp build not found - running "npm run build:webapp"...');


### PR DESCRIPTION
## Summary
- create `/data` volume in Dockerfile
- create `/data` if missing when starting the app
- add docker-compose file showing persistent volume
- document the volume in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d2f67515c8324958870c65bdaca0c