### PR TITLE
Fix stats.json module conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ node_modules/
 .vscode/settings.json
 *.tsbuildinfo
 /dist/
-src/store/stats.json
+src/store/stats.store.json
 src/store/*.db
 

--- a/dist/store/stats.js
+++ b/dist/store/stats.js
@@ -14,7 +14,13 @@ exports.getStats = getStats;
 exports.getAllStats = getAllStats;
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
-const statsPath = path_1.default.join(__dirname, 'stats.json');
+// Store stats outside the source folder if a /data volume is present to avoid
+// conflicts with the TypeScript module resolution.  When running locally
+// without the volume, keep the file next to this module but use a different
+// filename so Node does not load it instead of the .ts file.
+const statsPath = fs_1.default.existsSync('/data')
+    ? '/data/stats.json'
+    : path_1.default.join(__dirname, 'stats.store.json');
 let stats = {};
 let saveInterval = null;
 exports.seenChats = new Set();

--- a/src/store/stats.ts
+++ b/src/store/stats.ts
@@ -12,7 +12,13 @@ export interface UserStats {
   chats: number[];
 }
 
-const statsPath = path.join(__dirname, 'stats.json');
+// Store stats outside the source folder if a /data volume is present to avoid
+// conflicts with the TypeScript module resolution.  When running locally
+// without the volume, keep the file next to this module but use a different
+// filename so Node does not load it instead of the .ts file.
+const statsPath = fs.existsSync('/data')
+  ? '/data/stats.json'
+  : path.join(__dirname, 'stats.store.json');
 let stats: Record<string, UserStats> = {};
 let saveInterval: NodeJS.Timeout | null = null;
 export const seenChats = new Set<number>();


### PR DESCRIPTION
## Summary
- keep runtime stats JSON separate from TypeScript module
- rebuild dist store to match
- ignore new stats file name

## Testing
- `npm test`
- `npm run lint`
- `npx ts-node src/server.ts`

------
https://chatgpt.com/codex/tasks/task_e_687e63924d6083248ce90dc0cb80b6ae