### PR TITLE
Fix stats.json module conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ node_modules/
 .vscode/settings.json
 *.tsbuildinfo
 /dist/
-src/store/stats.json
+src/store/stats.store.json
 src/store/*.db
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -16,6 +16,24 @@ TELE_TOKEN=your_telegram_bot_token
 2. **TELE_TOKEN**: Your bot token from @BotFather
 3. **NODE_ENV**: Should be "production" (usually set automatically by Railway)
 
+## Quick Node Deployment
+
+1. **Create a project** on Railway and link this repository.
+2. **Set environment variables** as shown above, particularly `TELE_TOKEN` and
+   `PUBLIC_URL` (use your Railway URL).
+3. **Build Command** (if you override the default):
+   ```bash
+   npm install && cd webapp && npm install && npm run build && cd ..
+   ```
+4. **Start Command**:
+   ```bash
+   npm start
+   ```
+5. Run `railway up` or deploy via the dashboard. Railway will install
+   dependencies, build the app, and launch `node start.js` automatically.
+
+No Docker setup is required—Railway runs the Node.js server directly.
+
 ## Fixed Deployment Issues
 
 ### ✅ 1. Backend TypeScript Compilation

--- a/README.md
+++ b/README.md
@@ -58,10 +58,25 @@ npm start
 ```
 
 ### Deployment (Railway)
-The app is configured for Railway deployment with proper Nixpacks settings:
-- Builds both Node.js backend and React frontend
-- Serves static files from webapp/dist
-- No native dependencies (uses in-memory storage)
+You can deploy directly on Railway without Docker. Railway uses Nixpacks to
+install dependencies, build both the backend and React frontend, and then start
+`node start.js`.
+
+1. **Connect your repository** – Create a new Railway project and link this repo.
+2. **Configure environment variables** – Set at least `TELE_TOKEN` and
+   `PUBLIC_URL` (your Railway URL) in the dashboard.
+3. **Build command** – leave the default or set:
+   ```bash
+   npm install && cd webapp && npm install && npm run build && cd ..
+   ```
+4. **Start command** – use:
+   ```bash
+   npm start
+   ```
+5. Deploy with `railway up` or through the dashboard. The app will be available
+   at your Railway URL (e.g., `https://your-app.up.railway.app`).
+
+This workflow uses Node.js directly—no Docker is required.
 
 ## 🎯 Game Commands
 

--- a/dist/store/stats.js
+++ b/dist/store/stats.js
@@ -14,7 +14,13 @@ exports.getStats = getStats;
 exports.getAllStats = getAllStats;
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
-const statsPath = path_1.default.join(__dirname, 'stats.json');
+// Store stats outside the source folder if a /data volume is present to avoid
+// conflicts with the TypeScript module resolution.  When running locally
+// without the volume, keep the file next to this module but use a different
+// filename so Node does not load it instead of the .ts file.
+const statsPath = fs_1.default.existsSync('/data')
+    ? '/data/stats.json'
+    : path_1.default.join(__dirname, 'stats.store.json');
 let stats = {};
 let saveInterval = null;
 exports.seenChats = new Set();

--- a/src/store/stats.ts
+++ b/src/store/stats.ts
@@ -12,7 +12,13 @@ export interface UserStats {
   chats: number[];
 }
 
-const statsPath = path.join(__dirname, 'stats.json');
+// Store stats outside the source folder if a /data volume is present to avoid
+// conflicts with the TypeScript module resolution.  When running locally
+// without the volume, keep the file next to this module but use a different
+// filename so Node does not load it instead of the .ts file.
+const statsPath = fs.existsSync('/data')
+  ? '/data/stats.json'
+  : path.join(__dirname, 'stats.store.json');
 let stats: Record<string, UserStats> = {};
 let saveInterval: NodeJS.Timeout | null = null;
 export const seenChats = new Set<number>();


### PR DESCRIPTION
## Summary
- keep runtime stats JSON separate from TypeScript module
- rebuild dist store to match
- ignore new stats file name
- document how to deploy with Node on Railway

## Testing
- `npm test`
- `npm run lint`
- `npx ts-node src/server.ts`


------
https://chatgpt.com/codex/tasks/task_e_687e63924d6083248ce90dc0cb80b6ae