### PR TITLE
Fix Railway build process

### DIFF
--- a/.railwayignore
+++ b/.railwayignore
@@ -24,4 +24,4 @@ webapp/eslint.config.js
 # Temporary files
 *.log
 *.tmp
-.DS_Store 
+.DS_Store

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -52,9 +52,9 @@ No Docker setup is required—Railway runs the Node.js server directly.
 - **Result**: Multiple components can listen without conflicts
 
 ### ✅ 4. Build Process
-- **Problem**: Inconsistent build script names
-- **Fix**: Updated `package.json` scripts (`build:bot` + `build:webapp`)
-- **Result**: Both backend and frontend build successfully
+- **Problem**: Inconsistent build script names and missing backend compilation
+- **Fix**: `build:bot` now runs `tsc` and `build:webapp` builds the React app
+- **Result**: Both backend and frontend build successfully on Railway
 
 ## Build Verification
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:bot": "nodemon --exec ts-node src/server.ts",
     "dev:web": "cd webapp && npm run dev -- --host 0.0.0.0 --port 5173 --open",
     "dev": "concurrently -k \"npm run dev:bot\" \"npm run dev:web\"",
-    "build:bot": "echo 'Using pre-compiled dist files'",
+    "build:bot": "tsc",
     "build:webapp": "cd webapp && npm run build",
     "build": "npm run build:bot && npm run build:webapp",
     "clean:webapp": "rm -rf webapp/node_modules webapp/dist webapp/package-lock.json",


### PR DESCRIPTION
## Summary
- compile backend TypeScript on `npm run build`
- document backend compilation in deployment guide
- fix newline at end of `.railwayignore`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ebddba1c083248eeeec73cfb0d6bd