### PR TITLE
Adjust Vite base path for Vercel deployment

### DIFF
--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { visualizer } from 'rollup-plugin-visualizer'
+const basePath = process.env.VERCEL ? '/' : '/webapp/';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -13,7 +14,7 @@ export default defineConfig({
       brotliSize: true,
     }),
   ],
-  base: '/webapp/',
+  base: basePath,
   build: { 
     outDir: 'dist',
     target: 'es2020',


### PR DESCRIPTION
## Summary
- detect Vercel deployment in vite config
- use `/` as the base path on Vercel to avoid blank page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68854a9c39c083249bb7d0f82edf9174