### PR TITLE
Serve static webapp on Vercel via vercel.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Deploy the bot to [Fly.io](https://fly.io/) using the included `fly.toml`.
 This workflow uses Fly's Docker build system.
 
 ### Deployment (Vercel)
-The project can also be hosted on [Vercel](https://vercel.com/). Vercel now auto-detects the Node API functions and the `webapp` build output, so no `vercel.json` file is required.
+The project can also be hosted on [Vercel](https://vercel.com/). The repository includes a `vercel.json` file which builds the client in `webapp` and serves the static output from `webapp/dist` (defined in `vercel.json`). Only `/api/` requests are routed to the serverless functions.
 
 1. Install the [Vercel CLI](https://vercel.com/docs/cli) and run `vercel link` in this folder.
 2. Configure the following environment variables in the Vercel dashboard or via `vercel env add`:

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "version": 2,
+  "buildCommand": "npm --prefix webapp install && npm run --prefix webapp build",
+  "outputDirectory": "webapp/dist",
+  "rewrites": [ { "source": "/api/(.*)", "destination": "/api/$1" } ]
+}

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { visualizer } from 'rollup-plugin-visualizer'
-const basePath = process.env.VERCEL ? '/' : '/webapp/';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -14,7 +13,7 @@ export default defineConfig({
       brotliSize: true,
     }),
   ],
-  base: basePath,
+  base: '/',
   build: { 
     outDir: 'dist',
     target: 'es2020',


### PR DESCRIPTION
## Summary
- restore `vercel.json` to explicitly build the frontend and serve `webapp/dist`
- simplify Vite config by setting `base: '/'`
- document Vercel deployment using the new config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688550baf6d08324a7ffb581f35085cf